### PR TITLE
A better detectDefaultBranch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.23
+
+      - name: Unit tests
+        run: go test -v -coverprofile=cover.out ./...
+
+      - name: Send coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: cover.out
+
+      - name: Modver
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: bobg/modver@v2.10.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pull_request_url: https://github.com/${{ github.repository }}/pull/${{ github.event.number }}

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,8 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/bobg/taggo.svg)](https://pkg.go.dev/github.com/bobg/taggo)
 [![Go Report Card](https://goreportcard.com/badge/github.com/bobg/taggo)](https://goreportcard.com/report/github.com/bobg/taggo)
+[![Tests](https://github.com/bobg/taggo/actions/workflows/go.yml/badge.svg)](https://github.com/bobg/taggo/actions/workflows/go.yml)
+[![Coverage Status](https://coveralls.io/repos/github/bobg/taggo/badge.svg?branch=main)](https://coveralls.io/github/bobg/taggo?branch=main)
 
 This is taggo,
 a Go library and command

--- a/taggo.go
+++ b/taggo.go
@@ -293,7 +293,7 @@ func detectDefaultBranch(remoteRefs map[string]string, heads map[string]string) 
 		candidates  = set.Intersect(remoteNames, headNames)
 	)
 
-	for _, name := range []string{"main", "master", "default"} {
+	for _, name := range []string{"main", "master", "default", "trunk"} {
 		if candidates.Has(name) && remoteRefs[name] == heads[name] {
 			return name
 		}

--- a/taggo_test.go
+++ b/taggo_test.go
@@ -70,7 +70,7 @@ func TestCheckAll(t *testing.T) {
 			defer os.RemoveAll(tmpdir)
 
 			bundlePath := filepath.Join(testPath, "bundle")
-			cmd := exec.Command("git", "clone", bundlePath, tmpdir)
+			cmd := exec.Command("git", "clone", "-c", "init.defaultBranch=main", bundlePath, tmpdir)
 			cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 			if err := cmd.Run(); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
This PR improves the ability of `detectDefaultBranch` to do its job. It does not require the presence of a `HEAD` ref among the remotes. It also adds back GitHub Actions CI, which was previously removed as broken.