### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,7 @@
 name: Tests
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bobg/taggo/security/code-scanning/1](https://github.com/bobg/taggo/security/code-scanning/1)

To fix this issue, we should explicitly add a `permissions` block to the workflow. This can be added either at the top level (applies to all jobs) or inside the `test` job (applies just to this job). The most secure default is `contents: read`, which is sufficient for most workflow steps. Steps that require higher permissions (such as commenting on PRs) should be authorized as needed: either by setting a broader block at the job level or, for even stronger least privilege, by scoping the write permission just for that step (via a separate job if feasible, though this workflow doesn't split jobs). The best fix is to set `permissions: contents: read, pull-requests: write`, since the workflow comments on PRs only in the `pull_request` context.

**Changes to make:**

- Add a `permissions` block at the top level of the workflow (after the `name:` line and before the `on:` block, conventionally).
- Set `contents: read` (for basic access) and `pull-requests: write` (for the Modver step).
- No changes to imports or other functionality are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
